### PR TITLE
Render-prop-type-mods

### DIFF
--- a/src/Layouter.tsx
+++ b/src/Layouter.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 
-export type LayouterProps = {
+export type LayouterProps<T = any> = {
   cols: number;
-  items: any[];
-  render: React.FC<{ item: any }>;
+  items: T[];
+  render: React.FC<{ item: T }> | ((props: { item: T }) => React.ReactNode);
   gap?: number;
-  getId?: (item: any) => string | number;
-  getHeight?: (item: any) => number;
-  estimateHeight?: (item: any) => number;
+  getId?: (item: T) => string | number;
+  getHeight?: (item: T) => number;
+  estimateHeight?: (item: T) => number;
   mediaHeight?: number;
   breakpoints?: {
     [width: number]: {
@@ -42,7 +42,7 @@ function estimateHeightFromItem(item: any, mediaHeight?: number): number {
   return mediaHeight ? baseHeight + mediaHeight : baseHeight;
 }
 
-export default function Layouter({
+export default function Layouter<T>({
   cols,
   items,
   render: RenderItem,
@@ -52,7 +52,7 @@ export default function Layouter({
   estimateHeight,
   mediaHeight,
   breakpoints,
-}: LayouterProps) {
+}: LayouterProps<T>) {
   const [currentCols, setCurrentCols] = React.useState(cols);
 
   React.useEffect(() => {


### PR DESCRIPTION
The changes to the `render` prop type are significant and make it much more flexible. Here's a detailed breakdown:

1. **Before**:
```typescript
render: React.FC<{ item: any }>;
```
This only accepted a React functional component that took an `item` prop of type `any`.

2. **After**:
```typescript
render: React.FC<{ item: T }> | ((props: { item: T }) => React.ReactNode);
```
This new type accepts two different forms:

a) **Component Form**:
```typescript
React.FC<{ item: T }>
```
This allows passing a React functional component directly, like:
```typescript
render={CardWithImage}
```

b) **Render Function Form**:
```typescript
(props: { item: T }) => React.ReactNode
```
This allows passing an inline render function, like:
```typescript
render={({ item }) => (
  <CardWithImage description={item.description} title={item.title} />
)}
```

The key improvements are:
1. Type safety with the generic `T` instead of `any`
2. Support for both component and function patterns
3. More flexible return type (`React.ReactNode` instead of just component)
4. Better TypeScript inference for the `item` prop

This change makes the component more versatile while maintaining type safety, allowing developers to use whichever pattern they prefer.
